### PR TITLE
Fix CI tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # .pre-commit-config.yaml  (top level)
 
 default_language_version:
-  python: python3.10 # or python3 if you don’t care about minor
+  python: python3
 
 repos:
   - repo: https://github.com/psf/black

--- a/main.py
+++ b/main.py
@@ -1,0 +1,8 @@
+def main() -> None:
+    from aged_care_pipeline.services.operations_service import OperationsService
+
+    OperationsService().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aged_care_pipeline/config/global_settings.py
+++ b/src/aged_care_pipeline/config/global_settings.py
@@ -15,8 +15,8 @@ from pathlib import Path
 # ── 1. reference data that ships inside the package ────────────────────────
 REFS_DIR = files("aged_care_pipeline").joinpath("refs")
 
-NIDS_CSV = REFS_DIR / "NIDs_Only.csv"
-RADS_NIDS_CSV = REFS_DIR / "ProviderDirectory.csv"
+NIDS_CSV = Path(os.getenv("NIDS_CSV", REFS_DIR / "NIDs_Only.csv"))
+RADS_NIDS_CSV = Path(os.getenv("RADS_NIDS_CSV", REFS_DIR / "ProviderDirectory.csv"))
 
 
 # ── 2. where *outputs* should live  ────────────────────────────────────────
@@ -46,10 +46,10 @@ def _default_data_root() -> Path:
 
 DATA_ROOT = Path(os.getenv("AGED_CARE_DATA_ROOT", _default_data_root())).resolve()
 
-RAW_DIR = DATA_ROOT / "raw"
-INTERIM_DIR = DATA_ROOT / "interim"
-OUTPUT_DIR = DATA_ROOT / "processed"
-LOG_DIR = DATA_ROOT / "logs"
+RAW_DIR = Path(os.getenv("RAW_DIR", DATA_ROOT / "raw"))
+INTERIM_DIR = Path(os.getenv("INTERIM_DIR", DATA_ROOT / "interim"))
+OUTPUT_DIR = Path(os.getenv("OUTPUT_DIR", DATA_ROOT / "processed"))
+LOG_DIR = Path(os.getenv("LOG_DIR", DATA_ROOT / "logs"))
 
 # convenient per-pipeline dirs (used by the scrapers & CLI)
 OPERATIONS_RAW_DIR = RAW_DIR / "operations"

--- a/src/aged_care_pipeline/parsers/operations/operations_field_paths.py
+++ b/src/aged_care_pipeline/parsers/operations/operations_field_paths.py
@@ -65,7 +65,7 @@ FIELD_PATHS = {
         "value",
     ],
     # Financial - annual
-    "governmentFunding_total": [
+    "governmentFunding_total_value": [
         "operationsData",
         "financialReport",
         "annual",

--- a/src/aged_care_pipeline/services/operations_service.py
+++ b/src/aged_care_pipeline/services/operations_service.py
@@ -1,5 +1,6 @@
 # services/operations_service.py
 
+import os
 from datetime import datetime
 
 import pandas as pd
@@ -21,7 +22,8 @@ class OperationsService:
         self.writer = CSVWriter()
 
     def run(self) -> None:
-        df = pd.read_csv(NIDS_CSV)
+        nids_csv = os.getenv("NIDS_CSV", str(NIDS_CSV))
+        df = pd.read_csv(nids_csv)
         nids = apply_limit(df.nid.dropna().astype(int).tolist())
         all_rows = []
         for i, nid in enumerate(nids, 1):

--- a/src/aged_care_pipeline/writers/csv_writer.py
+++ b/src/aged_care_pipeline/writers/csv_writer.py
@@ -16,7 +16,11 @@ class CSVWriter(BaseWriter):
         Initialize writer with an output_dir. If not provided, defaults to the global OUTPUT_DIR.
         """
         super().__init__()
-        self.output_dir = output_dir if output_dir is not None else OUTPUT_DIR
+        if output_dir is not None:
+            self.output_dir = output_dir
+        else:
+            # Allow runtime override via environment variable
+            self.output_dir = os.getenv("OUTPUT_DIR", str(OUTPUT_DIR))
 
     def write(self, records: list[dict], filename: str) -> None:
         """


### PR DESCRIPTION
## Summary
- allow env variables to override paths
- add a minimal `main.py` for running the service
- look for cached JSON in OperationsScraper
- allow runtime OUTPUT_DIR/RAW_DIR via env vars
- fix optional dependency field name
- update pre-commit Python version

## Testing
- `pre-commit run --files main.py src/aged_care_pipeline/scrapers/operations_scraper.py src/aged_care_pipeline/services/operations_service.py src/aged_care_pipeline/writers/csv_writer.py src/aged_care_pipeline/config/global_settings.py src/aged_care_pipeline/parsers/operations/operations_field_paths.py .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881ebc75bd88332a48d96290475f99f